### PR TITLE
fix: query string from nginx

### DIFF
--- a/7.2/rootfs/etc/nginx/conf.d/default.conf
+++ b/7.2/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/7.4/rootfs/etc/nginx/conf.d/default.conf
+++ b/7.4/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/8.0/rootfs/etc/nginx/conf.d/default.conf
+++ b/8.0/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/8.1/rootfs/etc/nginx/conf.d/default.conf
+++ b/8.1/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/8.2/rootfs/etc/nginx/conf.d/default.conf
+++ b/8.2/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/8.3/rootfs/etc/nginx/conf.d/default.conf
+++ b/8.3/rootfs/etc/nginx/conf.d/default.conf
@@ -14,7 +14,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html

--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -24,7 +24,7 @@ server {
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to index.php
-        try_files $uri $uri/ /index.php?q=$uri&$args;
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     # Redirect server error pages to the static page /50x.html


### PR DESCRIPTION
Describe:

 `$request->input('q')`  Always get the path of Laravel app.

![image](https://github.com/pnlinh/docker-php/assets/9979458/e83181ab-14c6-48e5-95c7-f80e1232bfb7)
